### PR TITLE
exclude time_limit if it is less than or equal to 0

### DIFF
--- a/lib/imsqtiv1.py
+++ b/lib/imsqtiv1.py
@@ -2463,8 +2463,11 @@ class D2LTimeLimit(D2LBase):
 		self.data=self.data.strip()
 		if self.data:
 			try:
-				# d2l time is in minutes, qti does time in seconds
-				self.container.SetDuration("%s" % (float(self.data) * 60))
+				minutes = float(self.data)
+				# d2l exports set time_limit to 0 when no time limit is configured
+				if minutes > 0:
+					# d2l time is in minutes, qti does time in seconds
+					self.container.SetDuration("%s" % (minutes * 60))
 			except ValueError:
 				self.PrintWarning("Warning: invalid time limit value: %s" % self.data)
 


### PR DESCRIPTION
fixes: RCX-4813
flag=none

test plan:
- prereq: d2l export without no time limit quizzes
- visit /courses/${courseID}/content_migrations
- set content type to `D2L export .zip format`
- for source select the D2L export file
- click on `Add Import Queue` button
- wait for content import finish
- the quizzes should be imported with not time limit attribute